### PR TITLE
feat(OtherLinks): add secondary variant to FilledButton

### DIFF
--- a/src/components/OtherLinks.tsx
+++ b/src/components/OtherLinks.tsx
@@ -50,6 +50,7 @@ const OtherLinks: React.FC = () => (
 			{linksList.map((link, index) => (
 				<div key={index} className='p-1.5'>
 					<FilledButton
+						variant='secondary'
 						LeftIcon={link.icon}
 						onClick={() => window.open(link.url, '_blank')}
 						aria-label={link.ariaLabel}


### PR DESCRIPTION
Adds a secondary variant to the FilledButton component used in the
OtherLinks component. This provides a more subtle visual style for the
links, making them less prominent compared to the primary actions on the
page.