### PR TITLE
feat(WorkStatus): Use relative path for logo image

### DIFF
--- a/src/components/WorkStatus.tsx
+++ b/src/components/WorkStatus.tsx
@@ -26,7 +26,7 @@ const WorkStatus: React.FC<WorkStatusProps> = ({
 						<div className='flex flex-col sm:flex-row items-start sm:items-center pl-8 pt-8 pr-8 pb-0'>
 							<div className='w-16 h-16 sm:mr-4 relative flex-shrink-0'>
 								<Image
-									src='/public/logo-work.jpeg'
+									src='/logo-work.jpeg'
 									alt='Morressier logo'
 									fill
 									style={{ objectFit: 'contain' }}


### PR DESCRIPTION
The changes made in this commit are related to the `WorkStatus` component. The main change is
to use a relative path for the logo image instead of an absolute path. This is done to
improve the accessibility and maintainability of the application.