### PR TITLE
feat(WorkStatus): improve company logo display and job title

### DIFF
--- a/src/components/WorkStatus.tsx
+++ b/src/components/WorkStatus.tsx
@@ -29,18 +29,15 @@ const WorkStatus: React.FC<WorkStatusProps> = ({
 									src='/logo-work.jpeg'
 									alt='Morressier logo'
 									fill
-									style={{ objectFit: 'contain' }}
+									style={{ objectFit: 'cover' }}
 								/>
 							</div>
 							<div>
 								<h3 className='text-xl font-bold text-slate-900 dark:text-white'>
-									Morressier
+									Staff Product Designer
 								</h3>
 								<p className='text-slate-600 dark:text-slate-300'>
-									Staff Product Designer
-								</p>
-								<p className='text-slate-600 dark:text-slate-300'>
-									Berlin, Germany [2019]
+									Morressier, Berlin since 2019
 								</p>
 							</div>
 						</div>


### PR DESCRIPTION
Improve the display of the company logo by changing the `objectFit`
property to `cover` to ensure the image fills the container. Also,
update the job title to be more concise and the employment duration
to be more clear.