### PR TITLE
feat(deps): remove @heroicons/react dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "linkghost",
       "version": "0.1.0",
       "dependencies": {
-        "@heroicons/react": "^2.1.5",
         "lucide-react": "^0.446.0",
         "next": "14.2.13",
         "nextjs-google-analytics": "^2.3.7",
@@ -99,15 +98,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.5.tgz",
-      "integrity": "sha512-FuzFN+BsHa+7OxbvAERtgBTNeZpUjgM/MIizfVkSCL2/edriN0Hx/DWRCR//aPYwO5QX/YlgLGXk+E3PcfZwjA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {


### PR DESCRIPTION
The changes in this commit remove the `@heroicons/react` dependency from the project. This is done to reduce the overall dependency footprint and simplify the project's dependencies.