### PR TITLE
feat(homepage): remove unused `CallsToAction` and `WorkStatus` components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,19 +3,16 @@
 import React from 'react';
 import Header from '@/components/Header';
 // import CallsToAction from '@/components/CallsToAction';
-// import WorkStatus from '@/components/WorkStatus';
+// import WorkStatus from '@/components/WorkStatus'; // <WorkStatus isWorking={isCurrentlyWorking}>// // const isCurrentlyWorking = true;
 import Projects from '@/components/Projects';
 import OtherLinks from '@/components/OtherLinks';
 import Footer from '@/components/Footer';
 
 const HomePage: React.FC = () => {
-	// const isCurrentlyWorking = true;
 	return (
 		<main className='container mx-auto px-0 py-16 gap-16 flex flex-col'>
 			<Header />
-			{/* <CallsToAction /> */}
 			<Projects />
-			{/* <WorkStatus isWorking={isCurrentlyWorking} /> */}
 			<OtherLinks />
 			<Footer />
 		</main>


### PR DESCRIPTION
The changes in this commit include the removal of the unused `CallsToAction` and `WorkStatus` components from the `HomePage` component. This simplifies the code and removes unnecessary complexity from the homepage.