### PR TITLE
feat(button): add tooltip to square icon button

### DIFF
--- a/src/components/OtherLinks.tsx
+++ b/src/components/OtherLinks.tsx
@@ -3,44 +3,38 @@
 import React from 'react';
 import { FilledButton } from './atom/Button';
 import Section from './atom/Section';
-import { Book, Github, Linkedin, Twitter, Youtube, Rss } from 'lucide-react';
+import { Figma, Github, Newspaper, ListMusic, Linkedin } from 'lucide-react';
 
 const linksList = [
 	{
-		title: 'My Blog',
-		url: 'https://yourblog.com',
-		icon: Book,
-		ariaLabel: 'Visit My Blog',
+		title: 'Figma',
+		url: 'https://figma.com/@renderghost',
+		icon: Figma,
+		ariaLabel: 'Use my Shared Resources on Figma',
 	},
 	{
-		title: 'GitHub',
-		url: 'https://github.com/yourusername',
+		title: 'Github',
+		url: 'https://github.com/renderghost',
 		icon: Github,
-		ariaLabel: 'Check My GitHub',
+		ariaLabel: 'Contribute to Projects on GitHub',
+	},
+	{
+		title: 'Medium',
+		url: 'https://medium.com/@render_ghost',
+		icon: Newspaper,
+		ariaLabel: 'Read my Articles on Medium',
 	},
 	{
 		title: 'LinkedIn',
-		url: 'https://linkedin.com/in/yourusername',
+		url: 'https://www.linkedin.com/in/renderghost/',
 		icon: Linkedin,
-		ariaLabel: 'Connect on LinkedIn',
+		ariaLabel: 'Connect with me on LinkedIn',
 	},
 	{
-		title: 'Twitter',
-		url: 'https://twitter.com/yourusername',
-		icon: Twitter,
-		ariaLabel: 'Follow on Twitter',
-	},
-	{
-		title: 'YouTube',
-		url: 'https://youtube.com/yourchannel',
-		icon: Youtube,
-		ariaLabel: 'Subscribe to My YouTube Channel',
-	},
-	{
-		title: 'RSS Feed',
-		url: 'https://yourblog.com/rss',
-		icon: Rss,
-		ariaLabel: 'Subscribe to RSS Feed',
+		title: 'Spotify',
+		url: 'https://open.spotify.com/user/111112791',
+		icon: ListMusic,
+		ariaLabel: 'Listem to my Spotify Playlists',
 	},
 ];
 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -16,7 +16,7 @@ import {
 
 interface Project {
 	title: string;
-	description: string;
+	ariaLabel: string;
 	icon: React.FC<React.SVGProps<SVGSVGElement>>;
 	url: string;
 	sourceUrl?: string;
@@ -25,14 +25,14 @@ interface Project {
 const projectsList: Project[] = [
 	{
 		title: 'A11y Pixel',
-		description:
+		ariaLabel:
 			'Something about my own personal instagram for my amatuer photos.',
 		icon: PersonStanding,
 		url: 'https://www.figma.com/community/file/1392296486879607254/the-a11y-pixel',
 	},
 	{
 		title: 'Aperture',
-		description:
+		ariaLabel:
 			'Something about my own personal instagram for my amatuer photos.',
 		icon: Aperture,
 		url: 'https://frame.renderg.host/',
@@ -40,21 +40,21 @@ const projectsList: Project[] = [
 	},
 	{
 		title: 'Fictional Data',
-		description:
+		ariaLabel:
 			'Something about Fictional sample data for use in design prototypes for Science products.',
 		icon: BookType,
 		url: 'https://github.com/Morressier/fictional-design-data',
 	},
 	{
 		title: 'Ramps',
-		description: 'Something about an experimental gradient generator.',
+		ariaLabel: 'Something about an experimental gradient generator.',
 		icon: Radius,
 		url: 'https://ramps.renderg.host/',
 		sourceUrl: 'https://github.com/renderghost/ramps',
 	},
 	{
 		title: 'Spectra',
-		description:
+		ariaLabel:
 			'Something about generating hue palettes for design systems.',
 		icon: Aperture,
 		url: 'https://spectra.renderg.host/',
@@ -62,14 +62,14 @@ const projectsList: Project[] = [
 	},
 	{
 		title: 'Selections',
-		description: 'Something about Spotify playlists.',
+		ariaLabel: 'Something about Spotify playlists.',
 		icon: ListMusic,
 		url: 'https://selections.renderg.host/',
 		sourceUrl: 'https://github.com/renderghost/selections',
 	},
 	{
 		title: 'Strategy Schmategy',
-		description: 'Something about Generative design strategies.',
+		ariaLabel: 'Something about Generative design strategies.',
 		icon: Shuffle,
 		url: 'https://strategyschmategy.renderg.host/',
 		sourceUrl: 'https://github.com/renderghost/strategy-schmategy',
@@ -78,7 +78,7 @@ const projectsList: Project[] = [
 
 const ProjectCard: React.FC<Project> = ({
 	title,
-	description,
+	ariaLabel,
 	icon: Icon,
 	url,
 	sourceUrl,
@@ -89,7 +89,7 @@ const ProjectCard: React.FC<Project> = ({
 				<Icon className='w-8 h-8' />
 				<h3 className='font-semibold text-2xl'>{title}</h3>
 			</div>
-			<p className=''>{description}</p>
+			<p className=''>{ariaLabel}</p>
 		</div>
 		<div className='block'>
 			<div className='flex flex-wrap gap-3'>

--- a/src/components/atom/Banner.tsx
+++ b/src/components/atom/Banner.tsx
@@ -12,13 +12,13 @@ const Banner: React.FC = () => {
 					<span className=''>link.renderg.host</span>
 				</div>
 				<div className='flex items-center gap-2'>
-					<span className=''>Looking for more info about me?</span>
+					<span className=''>This site is for my bio links.</span>
 
 					<a
 						href='#'
 						className='flex items-center gap-1 hover:underline'
 					>
-						<span className='font-medium'>View my Portfolio</span>
+						<span className='font-semibold'>View my Portfolio</span>
 						<ExternalLinkIcon size={16} />
 					</a>
 				</div>

--- a/src/components/atom/Button.tsx
+++ b/src/components/atom/Button.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useRef } from 'react';
 
 // Button styles
 const buttonStyles = {
 	base: `
-    inline-flex items-center justify-center px-6 py-3 rounded
+    inline-flex items-center justify-center rounded
     font-semibold
     focus:outline-none focus:ring-offset-neutral-100 focus:ring-4 focus:ring-offset-2 focus:ring-attention-500
     transition-colors duration-200 ease-in-out
@@ -57,6 +57,49 @@ const getButtonClass = (
 	}`.trim();
 };
 
+// Tooltip Component
+interface TooltipProps {
+	children: React.ReactElement;
+	content: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ children, content }) => {
+	const [isVisible, setIsVisible] = useState(false);
+	const triggerRef = useRef<HTMLElement>(null);
+
+	const showTooltip = () => setIsVisible(true);
+	const hideTooltip = () => setIsVisible(false);
+
+	return (
+		<div className='relative inline-block'>
+			{React.cloneElement(children, {
+				ref: triggerRef,
+				onMouseEnter: showTooltip,
+				onMouseLeave: hideTooltip,
+				onFocus: showTooltip,
+				onBlur: hideTooltip,
+			})}
+			{isVisible && (
+				<div
+					role='tooltip'
+					className='absolute z-10 px-2 py-1 text-xs rounded 
+                     bg-black text-white 
+                     dark:bg-white dark:text-black 
+                     transition-opacity duration-150
+                     -translate-x-1/2 left-1/2 bottom-full mb-1
+                     whitespace-nowrap'
+				>
+					{content}
+					<div
+						className='absolute w-2 h-2 bg-black dark:bg-white rotate-45 
+                          -bottom-1 left-1/2 -translate-x-1/2'
+					/>
+				</div>
+			)}
+		</div>
+	);
+};
+
 // Button Props
 interface ButtonProps {
 	children: React.ReactNode;
@@ -66,6 +109,8 @@ interface ButtonProps {
 	disabled?: boolean;
 	LeftIcon?: React.FC<React.SVGProps<SVGSVGElement>>;
 	RightIcon?: React.FC<React.SVGProps<SVGSVGElement>>;
+	ariaLabel?: string;
+	tooltip?: string;
 }
 
 // Base Button Component
@@ -77,17 +122,35 @@ export const Button: React.FC<ButtonProps> = ({
 	disabled = false,
 	LeftIcon,
 	RightIcon,
-}) => (
-	<button
-		onClick={onClick}
-		className={`${getButtonClass(variant, disabled)} ${className}`}
-		disabled={disabled}
-	>
-		{LeftIcon && <LeftIcon className='w-6 h-6 mr-2' aria-hidden='true' />}
-		{children}
-		{RightIcon && <RightIcon className='w-6 h-6 ml-2' aria-hidden='true' />}
-	</button>
-);
+	ariaLabel,
+	tooltip,
+}) => {
+	const buttonContent = (
+		<button
+			onClick={onClick}
+			className={`px-6 py-3 ${getButtonClass(
+				variant,
+				disabled,
+			)} ${className}`}
+			disabled={disabled}
+			aria-label={ariaLabel}
+		>
+			{LeftIcon && (
+				<LeftIcon className='w-6 h-6 mr-2' aria-hidden='true' />
+			)}
+			{children}
+			{RightIcon && (
+				<RightIcon className='w-6 h-6 ml-2' aria-hidden='true' />
+			)}
+		</button>
+	);
+
+	return tooltip ? (
+		<Tooltip content={tooltip}>{buttonContent}</Tooltip>
+	) : (
+		buttonContent
+	);
+};
 
 // Specific Button Variants
 export const TextButton: React.FC<ButtonProps> = props => (
@@ -105,7 +168,8 @@ interface SquareIconButtonProps {
 	className?: string;
 	variant?: 'primary' | 'secondary' | 'transparent' | 'card';
 	disabled?: boolean;
-	'aria-label': string;
+	ariaLabel: string;
+	tooltip?: string;
 }
 
 export const SquareIconButton: React.FC<SquareIconButtonProps> = ({
@@ -114,20 +178,29 @@ export const SquareIconButton: React.FC<SquareIconButtonProps> = ({
 	className = '',
 	variant = 'primary',
 	disabled = false,
-	'aria-label': ariaLabel,
-}) => (
-	<button
-		onClick={onClick}
-		className={`${getButtonClass(
-			variant,
-			disabled,
-		)} flex px-2 items-center justify-center ${className}`}
-		disabled={disabled}
-		aria-label={ariaLabel}
-	>
-		<Icon className='w-6 h-6' aria-hidden='true' />
-	</button>
-);
+	ariaLabel,
+	tooltip,
+}) => {
+	const buttonContent = (
+		<button
+			onClick={onClick}
+			className={`px-3 py-3 ${getButtonClass(
+				variant,
+				disabled,
+			)} flex items-center justify-center ${className}`}
+			disabled={disabled}
+			aria-label={ariaLabel}
+		>
+			<Icon className='w-6 h-6' aria-hidden='true' />
+		</button>
+	);
+
+	return tooltip ? (
+		<Tooltip content={tooltip}>{buttonContent}</Tooltip>
+	) : (
+		buttonContent
+	);
+};
 
 // Card Button
 export const CardButton: React.FC<ButtonProps> = ({
@@ -136,15 +209,26 @@ export const CardButton: React.FC<ButtonProps> = ({
 	className = '',
 	variant = 'card',
 	disabled = false,
-}) => (
-	<button
-		onClick={onClick}
-		className={`${getButtonClass(
-			variant,
-			disabled,
-		)} w-full text-left flex flex-col p-4 ${className}`}
-		disabled={disabled}
-	>
-		{children}
-	</button>
-);
+	ariaLabel,
+	tooltip,
+}) => {
+	const buttonContent = (
+		<button
+			onClick={onClick}
+			className={`${getButtonClass(
+				variant,
+				disabled,
+			)} w-full text-left flex flex-col p-4 ${className}`}
+			disabled={disabled}
+			aria-label={ariaLabel}
+		>
+			{children}
+		</button>
+	);
+
+	return tooltip ? (
+		<Tooltip content={tooltip}>{buttonContent}</Tooltip>
+	) : (
+		buttonContent
+	);
+};

--- a/src/components/atom/SocialLinks.tsx
+++ b/src/components/atom/SocialLinks.tsx
@@ -8,7 +8,7 @@ interface SocialLink {
 	title: string;
 	url: string;
 	icon: React.FC<React.SVGProps<SVGSVGElement>>;
-	description?: string;
+	ariaLabel: string;
 }
 
 const socialLinks: SocialLink[] = [
@@ -16,42 +16,42 @@ const socialLinks: SocialLink[] = [
 		title: 'Figma',
 		url: 'https://figma.com/@renderghost',
 		icon: Figma,
-		description: 'Use my Shared Resources on Figma',
+		ariaLabel: 'Use my Shared Resources on Figma',
 	},
 	{
 		title: 'Github',
 		url: 'https://github.com/renderghost',
 		icon: Github,
-		description: 'Contribute to Projects on GitHub',
+		ariaLabel: 'Contribute to Projects on GitHub',
 	},
 	{
 		title: 'Medium',
 		url: 'https://medium.com/@render_ghost',
 		icon: Newspaper,
-		description: 'Read my Articles on Medium',
+		ariaLabel: 'Read my Articles on Medium',
 	},
 	{
 		title: 'LinkedIn',
 		url: 'https://www.linkedin.com/in/renderghost/',
 		icon: Linkedin,
-		description: 'Connect with me on LinkedIn',
+		ariaLabel: 'Connect with me on LinkedIn',
 	},
 	{
 		title: 'Spotify',
 		url: 'https://open.spotify.com/user/111112791',
 		icon: ListMusic,
-		description: 'Listem to my Spotify Playlists',
+		ariaLabel: 'Listen to my Spotify Playlists',
 	},
 ];
 
 const SocialLink: React.FC<SocialLink> = React.memo(
-	({ title, url, icon: Icon, description }) => (
+	({ title, url, icon: Icon, ariaLabel }) => (
 		<SquareIconButton
 			Icon={Icon}
 			variant='secondary'
 			onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
-			aria-label={description || title}
-			className='px-3 py-3'
+			ariaLabel={ariaLabel || title}
+			className=''
 		/>
 	),
 );

--- a/src/components/atom/Tooltip.tsx
+++ b/src/components/atom/Tooltip.tsx
@@ -1,0 +1,55 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface TooltipProps {
+	children: React.ReactElement;
+	content: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ children, content }) => {
+	const [isVisible, setIsVisible] = useState(false);
+	const triggerRef = useRef<HTMLElement>(null);
+	const tooltipRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const trigger = triggerRef.current;
+		if (trigger) {
+			trigger.setAttribute('aria-describedby', 'tooltip');
+		}
+	}, []);
+
+	const showTooltip = () => setIsVisible(true);
+	const hideTooltip = () => setIsVisible(false);
+
+	return (
+		<div className='relative inline-block'>
+			{React.cloneElement(children, {
+				ref: triggerRef,
+				onMouseEnter: showTooltip,
+				onMouseLeave: hideTooltip,
+				onFocus: showTooltip,
+				onBlur: hideTooltip,
+			})}
+			{isVisible && (
+				<div
+					ref={tooltipRef}
+					id='tooltip'
+					role='tooltip'
+					className='absolute z-10 px-2 py-1 text-xs rounded 
+                     bg-neutral-0 text-neutral-100 
+                     dark:bg-neutral-100 dark:text-neutral-0 
+                     transition-opacity duration-150
+                     -translate-x-1/2 left-1/2 bottom-full mb-1
+                     whitespace-nowrap'
+				>
+					{content}
+					<div
+						className='absolute w-2 h-2 bg-neutral-0 dark:bg-neutral-100 rotate-45 
+                          -bottom-1 left-1/2 -translate-x-1/2'
+					/>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Tooltip;


### PR DESCRIPTION
This change adds a tooltip feature to the `SquareIconButton` component in the `Button.tsx` file. The `tooltip` prop is added to the component, and if provided, the button is wrapped in a `Tooltip` component to display the tooltip content when the button is hovered or focused.

Additionally, the `ariaLabel` prop is renamed from `'aria-label'` to `ariaLabel` for consistency with other props.

The `Tooltip` component is also added in the `Tooltip.tsx` file, providing the functionality to display a tooltip over a child element.

Finally, the `ariaLabel` prop is added to the `ButtonProps` interface to support accessibility features for the base button component.