### PR TITLE
feat: add new projects to the Projects component

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -41,6 +41,13 @@ const projectsList: Project[] = [
 		sourceUrl: 'https://github.com/renderghost/frame',
 	},
 	{
+		title: 'ChattyFile',
+		ariaLabel: 'Chrome Extension to upload larger text files to ChatGPT!',
+		icon: BookType,
+		url: 'https://chromewebstore.google.com/detail/chatty-file-uploader/hkaeghidfjhncjnajpbmdhpcpfhkacmp',
+		sourceUrl: 'https://github.com/renderghost/chattyfile',
+	},
+	{
 		title: 'Fictional Data',
 		ariaLabel:
 			'Fake science data that looks real. Perfect for making your science app mockups look legit!',
@@ -62,6 +69,13 @@ const projectsList: Project[] = [
 		icon: Radius,
 		url: 'https://ramps.renderg.host/',
 		sourceUrl: 'https://github.com/renderghost/ramps',
+	},
+	{
+		title: 'ScienceUX',
+		ariaLabel:
+			'A journal looking into the science behind designing for scientific products.',
+		icon: SwatchBook,
+		url: 'https://scienceux.org/',
 	},
 	{
 		title: 'Spectra',


### PR DESCRIPTION
This commit adds two new projects to the `Projects` component:

1. `ScienceUX`: A journal looking into the science behind designing for scientific
   products.
2. `ChattyFile`: A Chrome extension to upload larger text files to ChatGPT.

These new projects are added to showcase the diverse range of work the developer
has been involved in, from scientific design to browser extensions.