### PR TITLE
feat(projects): add new project icons and update existing ones

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -14,6 +14,8 @@ import {
 	BookType,
 	Ghost,
 	SwatchBook,
+	FlaskConical,
+	BotMessageSquare,
 } from 'lucide-react';
 
 interface Project {
@@ -43,7 +45,7 @@ const projectsList: Project[] = [
 	{
 		title: 'ChattyFile',
 		ariaLabel: 'Chrome Extension to upload larger text files to ChatGPT!',
-		icon: BookType,
+		icon: BotMessageSquare,
 		url: 'https://chromewebstore.google.com/detail/chatty-file-uploader/hkaeghidfjhncjnajpbmdhpcpfhkacmp',
 		sourceUrl: 'https://github.com/renderghost/chattyfile',
 	},
@@ -74,7 +76,7 @@ const projectsList: Project[] = [
 		title: 'ScienceUX',
 		ariaLabel:
 			'A journal looking into the science behind designing for scientific products.',
-		icon: SwatchBook,
+		icon: FlaskConical,
 		url: 'https://scienceux.org/',
 	},
 	{


### PR DESCRIPTION
This commit introduces new project icons and updates existing ones in the
`Projects` component. The changes are as follows:

- Adds the `FlaskConical` icon from the `lucide-react` library to represent
  the "ScienceUX" project.
- Replaces the `BookType` icon with the `BotMessageSquare` icon for the
  "ChattyFile" project.

These changes are made to improve the visual representation of the projects
and provide more relevant and recognizable icons for the user.