### PR TITLE
refactor: replace individual card components with a unified Card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React from 'react';
-import Creations from '@/components/sections/Creations';
-import Projects from '@/components/sections/Projects';
+import Creations from '@/components/Section/Creations';
+import Projects from '@/components/Section/Projects';
 import Articles from '@/components/Section/Articles';
-import OtherLinks from '@/components/sections/OtherLinks';
+import OtherLinks from '@/components/Section/OtherLinks';
 
 const HomePage: React.FC = () => {
 	return (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import { ExternalLink, Github } from 'lucide-react';
+import { FilledButton } from '../Button/Button';
 import type { CardProps } from './Card.types';
 import {
 	cardBase,
@@ -15,10 +17,9 @@ const Card: React.FC<CardProps> = ({
 	title,
 	description,
 	icon: Icon,
-	actions,
-	schemaType = 'CreativeWork',
 	url,
 	sourceUrl,
+	schemaType = 'CreativeWork',
 	className = '',
 }) => {
 	return (
@@ -37,7 +38,32 @@ const Card: React.FC<CardProps> = ({
 					{description}
 				</p>
 			</div>
-			{actions && <div className={cardActions}>{actions}</div>}
+
+			{(url || sourceUrl) && (
+				<div className={cardActions}>
+					{url && (
+						<FilledButton
+							variant='secondary'
+							RightIcon={ExternalLink}
+							onClick={() => window.open(url, '_blank')}
+							ariaLabel={`View ${title}`}
+							tooltip={`View ${title}`}>
+							View
+						</FilledButton>
+					)}
+					{sourceUrl && (
+						<FilledButton
+							variant='transparent'
+							RightIcon={Github}
+							onClick={() => window.open(sourceUrl, '_blank')}
+							ariaLabel={`View source code for ${title}`}
+							tooltip={`View source code for ${title}`}>
+							View Source
+						</FilledButton>
+					)}
+				</div>
+			)}
+
 			{url && <link itemProp='url' href={url} />}
 			{sourceUrl && <link itemProp='codeRepository' href={sourceUrl} />}
 		</div>

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -4,9 +4,8 @@ export interface CardProps {
 	title: string;
 	description: string;
 	icon: React.FC<React.SVGProps<SVGSVGElement>>;
-	actions?: React.ReactNode;
-	schemaType?: string;
 	url?: string;
 	sourceUrl?: string;
+	schemaType?: string;
 	className?: string;
 }

--- a/src/components/Section/Articles.tsx
+++ b/src/components/Section/Articles.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import React from 'react';
-import { FilledButton } from '../Button/Button';
+
 import Section from './Section';
-import { ExternalLink, Newspaper, Youtube } from 'lucide-react';
+import Card from '../Card/Card';
+
+import { Newspaper, Youtube } from 'lucide-react';
 
 interface Article {
 	title: string;
@@ -71,43 +73,6 @@ const articlesList: Article[] = [
 	},
 ];
 
-const ArticleCard: React.FC<Article> = ({
-	title,
-	ariaLabel,
-	icon: Icon,
-	url,
-}) => (
-	<div className='card' itemScope itemType='http://schema.org/Article'>
-		<div className='flex flex-col gap-2 '>
-			<div className='flex items-center gap-2'>
-				<Icon className='w-7 h-7' />
-				<h3 className='text-xl font-medium' itemProp='headline'>
-					{title}
-				</h3>
-			</div>
-			<p
-				className='text-bones-black dark:text-bones-white'
-				itemProp='description'>
-				{ariaLabel}
-			</p>
-		</div>
-		<div className='block'>
-			<div className='flex flex-wrap gap-4'>
-				<FilledButton
-					variant='secondary'
-					RightIcon={ExternalLink}
-					onClick={() => window.open(url, '_blank')}
-					ariaLabel={`View article`}
-					// tooltip={`View article`}
-				>
-					View Article
-				</FilledButton>
-			</div>
-		</div>
-		<link itemProp='url' href={url} />
-	</div>
-);
-
 const Articles: React.FC = () => (
 	<Section
 		id='my-articles'
@@ -124,7 +89,13 @@ const Articles: React.FC = () => (
 					itemScope
 					itemType='http://schema.org/ListItem'
 					className='flex flex-col flex-grow'>
-					<ArticleCard {...article} />
+					<Card
+						title={article.title}
+						description={article.ariaLabel}
+						icon={article.icon}
+						schemaType='Article'
+						url={article.url}
+					/>
 					<meta itemProp='position' content={`${index + 1}`} />
 				</div>
 			))}

--- a/src/components/Section/Creations.tsx
+++ b/src/components/Section/Creations.tsx
@@ -1,14 +1,12 @@
 'use client';
 
 import React from 'react';
-import { FilledButton } from '../Button/Button';
 import Section from '../Section/Section';
+import Card from '../Card/Card';
 import {
 	Aperture,
 	Shuffle,
-	ExternalLink,
 	KeyboardMusic,
-	Github,
 	Radius,
 	ListMusic,
 } from 'lucide-react';
@@ -63,54 +61,6 @@ const creationsList: Creation[] = [
 	},
 ];
 
-const CreationCard: React.FC<Creation> = ({
-	title,
-	ariaLabel,
-	icon: Icon,
-	url,
-	sourceUrl,
-}) => (
-	<div className='card' itemScope itemType='http://schema.org/CreativeWork'>
-		<div className='flex flex-col gap-2'>
-			<div className='flex items-center gap-2'>
-				<Icon className='w-7 h-7' />
-				<h3 className='font-medium text-xl' itemProp='name'>
-					{title}
-				</h3>
-			</div>
-			<p
-				className='text-bones-black dark:text-bones-white'
-				itemProp='description'>
-				{ariaLabel}
-			</p>
-		</div>
-		<div className='block'>
-			<div className='flex flex-wrap gap-4'>
-				<FilledButton
-					variant='secondary'
-					RightIcon={ExternalLink}
-					onClick={() => window.open(url, '_blank')}
-					ariaLabel={`View ${title} creation`}
-					tooltip={`View ${title} creation`}>
-					View Creation
-				</FilledButton>
-				{sourceUrl && (
-					<FilledButton
-						variant='transparent'
-						RightIcon={Github}
-						onClick={() => window.open(sourceUrl, '_blank')}
-						ariaLabel={`View source code for ${title}`}
-						tooltip={`View source code for ${title}`}>
-						View Source
-					</FilledButton>
-				)}
-			</div>
-		</div>
-		<link itemProp='url' href={url} />
-		{sourceUrl && <link itemProp='codeRepository' href={sourceUrl} />}
-	</div>
-);
-
 const Creations: React.FC = () => (
 	<Section
 		id='my-creations'
@@ -127,7 +77,14 @@ const Creations: React.FC = () => (
 					itemScope
 					itemType='http://schema.org/ListItem'
 					className='flex flex-col flex-grow'>
-					<CreationCard {...creation} />
+					<Card
+						title={creation.title}
+						description={creation.ariaLabel}
+						icon={creation.icon}
+						schemaType='CreativeWork'
+						url={creation.url}
+						sourceUrl={creation.sourceUrl}
+					/>
 					<meta itemProp='position' content={`${index + 1}`} />
 				</div>
 			))}

--- a/src/components/Section/Projects.tsx
+++ b/src/components/Section/Projects.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import React from 'react';
-import { FilledButton } from '../Button/Button';
 import Section from '../Section/Section';
+import Card from '../Card/Card';
 import {
-	ExternalLink,
-	Github,
 	PersonStanding,
 	BookType,
 	SwatchBook,
@@ -17,7 +15,7 @@ interface Project {
 	title: string;
 	ariaLabel: string;
 	icon: React.FC<React.SVGProps<SVGSVGElement>>;
-	url: string;
+	url?: string;
 	sourceUrl?: string;
 }
 
@@ -61,57 +59,6 @@ const projectsList: Project[] = [
 	},
 ];
 
-const ProjectCard: React.FC<Project> = ({
-	title,
-	ariaLabel,
-	icon: Icon,
-	url,
-	sourceUrl,
-}) => (
-	<div
-		className='card'
-		itemScope
-		itemType='http://schema.org/SoftwareApplication'>
-		<div className='flex flex-col gap-2'>
-			<div className='flex items-center gap-2'>
-				<Icon className='w-7 h-7' />
-				<h3 className='font-medium text-xl' itemProp='name'>
-					{title}
-				</h3>
-			</div>
-			<p
-				className='text-bones-black dark:text-bones-white'
-				itemProp='description'>
-				{ariaLabel}
-			</p>
-		</div>
-		<div className='block'>
-			<div className='flex flex-wrap gap-4'>
-				<FilledButton
-					variant='secondary'
-					RightIcon={ExternalLink}
-					onClick={() => window.open(url, '_blank')}
-					ariaLabel={`View ${title} project`}
-					tooltip={`View ${title} project`}>
-					View Project
-				</FilledButton>
-				{sourceUrl && (
-					<FilledButton
-						variant='transparent'
-						RightIcon={Github}
-						onClick={() => window.open(sourceUrl, '_blank')}
-						ariaLabel={`View source code for ${title}`}
-						tooltip={`View source code for ${title}`}>
-						View Source
-					</FilledButton>
-				)}
-			</div>
-		</div>
-		<link itemProp='url' href={url} />
-		{sourceUrl && <link itemProp='codeRepository' href={sourceUrl} />}
-	</div>
-);
-
 const Projects: React.FC = () => (
 	<Section
 		id='my-lab'
@@ -128,7 +75,14 @@ const Projects: React.FC = () => (
 					itemScope
 					itemType='http://schema.org/ListItem'
 					className='flex flex-col flex-grow'>
-					<ProjectCard {...project} />
+					<Card
+						title={project.title}
+						description={project.ariaLabel}
+						icon={project.icon}
+						schemaType='SoftwareApplication'
+						url={project.url}
+						sourceUrl={project.sourceUrl}
+					/>
 					<meta itemProp='position' content={`${index + 1}`} />
 				</div>
 			))}

--- a/src/components/Section/Work.tsx
+++ b/src/components/Section/Work.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React from 'react';
-import { FilledButton } from '../Button/Button';
 import Section from '../Section/Section';
-import { Aperture, ExternalLink, Github, ListMusic } from 'lucide-react';
+import Card from '../Card/Card';
+import { Aperture, ListMusic } from 'lucide-react';
 
 interface Work {
 	title: string;
@@ -31,57 +31,6 @@ const worksList: Work[] = [
 	},
 ];
 
-const WorkCard: React.FC<Work> = ({
-	title,
-	ariaLabel,
-	icon: Icon,
-	url,
-	sourceUrl,
-}) => (
-	<div
-		className='bg-bones-white dark:bg-bones-black  flex flex-col flex-grow justify-between gap-8 p-8'
-		itemScope
-		itemType='http://schema.org/CreativeWork'>
-		<div className='flex flex-col gap-2'>
-			<div className='flex items-center gap-2'>
-				<Icon className='w-7 h-7' />
-				<h3 className='font-medium text-xl' itemProp='name'>
-					{title}
-				</h3>
-			</div>
-			<p
-				className='text-bones-black dark:text-bones-white'
-				itemProp='description'>
-				{ariaLabel}
-			</p>
-		</div>
-		<div className='block'>
-			<div className='flex flex-wrap gap-4'>
-				<FilledButton
-					variant='secondary'
-					RightIcon={ExternalLink}
-					onClick={() => window.open(url, '_blank')}
-					ariaLabel={`View ${title} creation`}
-					tooltip={`View ${title} creation`}>
-					View Work
-				</FilledButton>
-				{sourceUrl && (
-					<FilledButton
-						variant='transparent'
-						RightIcon={Github}
-						onClick={() => window.open(sourceUrl, '_blank')}
-						ariaLabel={`View source code for ${title}`}
-						tooltip={`View source code for ${title}`}>
-						View Source
-					</FilledButton>
-				)}
-			</div>
-		</div>
-		<link itemProp='url' href={url} />
-		{sourceUrl && <link itemProp='codeRepository' href={sourceUrl} />}
-	</div>
-);
-
 const Works: React.FC = () => (
 	<Section
 		id='my-works'
@@ -91,14 +40,21 @@ const Works: React.FC = () => (
 			className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'
 			itemScope
 			itemType='http://schema.org/ItemList'>
-			{worksList.map((creation, index) => (
+			{worksList.map((work, index) => (
 				<div
 					key={index}
 					itemProp='itemListElement'
 					itemScope
 					itemType='http://schema.org/ListItem'
-					className='flex flex-col flex-grow'>
-					<WorkCard {...creation} />
+					className='cardRack'>
+					<Card
+						title={work.title}
+						description={work.ariaLabel}
+						icon={work.icon}
+						schemaType='CreativeWork'
+						url={work.url}
+						sourceUrl={work.sourceUrl}
+					/>
 					<meta itemProp='position' content={`${index + 1}`} />
 				</div>
 			))}


### PR DESCRIPTION
Consolidate multiple card components into a single reusable 
Card component to improve code maintainability and reduce 
redundancy. Update Projects, Creations, and Works sections 
to utilize the new Card component, streamlining the rendering 
of project and creation details.