### PR TITLE
fix: update URLs for Creations and Projects sections

### DIFF
--- a/src/components/Section/Sections/Creations.tsx
+++ b/src/components/Section/Sections/Creations.tsx
@@ -19,8 +19,7 @@ const creationsList = [
 		description:
 			'Playing with text and image generating LLMs to create an ever evolving science fiction storyline.',
 		icon: Sparkles,
-		url: 'https://strategyschmategy.renderg.host/',
-		sourceUrl: 'https://github.com/renderghost/strategy-schmategy',
+		url: 'https://www.instagram.com/tri_mph_nt/',
 	},
 	{
 		title: 'Aperture',

--- a/src/components/Section/Sections/Projects.tsx
+++ b/src/components/Section/Sections/Projects.tsx
@@ -17,7 +17,7 @@ const projectsList = [
 		description:
 			'Invisible Figma component to help document Accessibility attributes in design files at any level of specificity.',
 		icon: PersonStanding,
-		url: 'https://www.figma.com/community/file/1392296486879607254/the-a11y-pixel',
+		url: 'https://www.figma.com/community/file/1468516979425643600/the-a11y-pixel',
 	},
 	{
 		title: 'Bones',


### PR DESCRIPTION
Change the Creations item URL to point to the Instagram profile
instead of the previous website and remove the source URL. Update the
Projects item URL to the latest Figma community file link. These updates
ensure that links remain current and direct users to the correct resources.